### PR TITLE
Autoload www/TwilioVoicePlugin.js

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,9 @@
     <author>Jeff Linwood/Stevie Graham/Lyle Pratt</author>
     <license>MIT</license>
 
-    <asset src="www/TwilioVoicePlugin.js" target="js/TwilioVoicePlugin.js" />
+    <js-module src="www/TwilioVoicePlugin.js" name="TwilioVoicePlugin">
+        <clobbers target="Twilio.TwilioVoiceClient" />
+    </js-module>
 
     <engines>
         <engine name="cordova" version=">=6.4.0"/>
@@ -39,12 +41,12 @@
         <dependency id="phonegap-plugin-push"/>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-        
+
         <receiver android:name="com.phonegap.plugins.twiliovoice.BootCompletedReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>
-        </receiver>     
+        </receiver>
 
         <service
             android:name="com.phonegap.plugins.twiliovoice.gcm.VoiceGCMListenerService"
@@ -81,7 +83,7 @@
             <string name="gcm_sender_id" translatable="false">$GCM_SENDER_ID</string>
             <string name="incoming_call_app_name" translatable="false">$INCOMING_CALL_APP_NAME</string>
         </config-file>
-        
+
         <framework src="com.google.android.gms:play-services-gcm:9.4.0" />
         <framework src="com.twilio:voice-android:2.0.0-beta4"/>
 
@@ -148,7 +150,7 @@
         <config-file target="*/Entitlements-Release.plist" parent="aps-environment">
           <string>production</string>
         </config-file>
-        
+
 
         <header-file src="src/ios/TwilioVoicePlugin.h" />
         <source-file src="src/ios/TwilioVoicePlugin.m" />

--- a/www/TwilioVoicePlugin.js
+++ b/www/TwilioVoicePlugin.js
@@ -1,50 +1,49 @@
-(function() {
+(function(module, require) {
+    var exec = require("cordova/exec")
     var delegate = {}
-    var TwilioPlugin = {
 
-        TwilioVoiceClient: function() {
-            return this;
-        }
+    function TwilioVoiceClient() {
+        return this;
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.call = function(token, params) {
-        Cordova.exec(null,null,"TwilioVoicePlugin","call",[token, params]);
+    TwilioVoiceClient.prototype.call = function(token, params) {
+        exec(null, null, "TwilioVoicePlugin", "call", [token, params]);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.sendDigits = function(digits) {
-        Cordova.exec(null,null,"TwilioVoicePlugin","sendDigits",[digits]);
+    TwilioVoiceClient.prototype.sendDigits = function(digits) {
+        exec(null, null, "TwilioVoicePlugin", "sendDigits", [digits]);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.disconnect = function() {
-        Cordova.exec(null,null,"TwilioVoicePlugin","disconnect",null);
+    TwilioVoiceClient.prototype.disconnect = function() {
+        exec(null, null, "TwilioVoicePlugin", "disconnect", null);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.rejectCallInvite = function() {
-        Cordova.exec(null,null,"TwilioVoicePlugin","rejectCallInvite",null);
+    TwilioVoiceClient.prototype.rejectCallInvite = function() {
+        exec(null, null, "TwilioVoicePlugin", "rejectCallInvite", null);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.acceptCallInvite = function() {
-        Cordova.exec(null,null,"TwilioVoicePlugin","acceptCallInvite",null);
+    TwilioVoiceClient.prototype.acceptCallInvite = function() {
+        exec(null, null, "TwilioVoicePlugin", "acceptCallInvite", null);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.setSpeaker = function(mode) {
-        // "on" or "off"        
-        Cordova.exec(null, null, "TwilioVoicePlugin", "setSpeaker", [mode]);
+    TwilioVoiceClient.prototype.setSpeaker = function(mode) {
+        // "on" or "off"
+        exec(null, null, "TwilioVoicePlugin", "setSpeaker", [mode]);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.muteCall = function() {
-        Cordova.exec(null, null, "TwilioVoicePlugin", "muteCall", null);
+    TwilioVoiceClient.prototype.muteCall = function() {
+        exec(null, null, "TwilioVoicePlugin", "muteCall", null);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.unmuteCall = function() {
-        Cordova.exec(null, null, "TwilioVoicePlugin", "unmuteCall", null);
+    TwilioVoiceClient.prototype.unmuteCall = function() {
+        exec(null, null, "TwilioVoicePlugin", "unmuteCall", null);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.isCallMuted = function(fn) {
-        Cordova.exec(fn, null, "TwilioVoicePlugin", "isCallMuted", null);
+    TwilioVoiceClient.prototype.isCallMuted = function(fn) {
+        exec(fn, null, "TwilioVoicePlugin", "isCallMuted", null);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.initialize = function(token) {
+    TwilioVoiceClient.prototype.initialize = function(token) {
 
         var error = function(error) {
             //TODO: Handle errors here
@@ -57,38 +56,33 @@
         }
 
 
-        Cordova.exec(success,error,"TwilioVoicePlugin","initializeWithAccessToken",[token]);
+        exec(success, error, "TwilioVoicePlugin", "initializeWithAccessToken", [token]);
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.error = function(fn) {
+    TwilioVoiceClient.prototype.error = function(fn) {
         delegate['onerror'] = fn;
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.clientinitialized = function(fn) {
+    TwilioVoiceClient.prototype.clientinitialized = function(fn) {
         delegate['onclientinitialized'] = fn;
     }
 
-
-    TwilioPlugin.TwilioVoiceClient.prototype.callinvitereceived = function(fn) {
+    TwilioVoiceClient.prototype.callinvitereceived = function(fn) {
         delegate['oncallinvitereceived'] = fn;
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.callinvitecanceled = function(fn) {
+    TwilioVoiceClient.prototype.callinvitecanceled = function(fn) {
         delegate['oncallinvitecanceled'] = fn;
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.calldidconnect = function(fn) {
+    TwilioVoiceClient.prototype.calldidconnect = function(fn) {
         delegate['oncalldidconnect'] = fn;
     }
 
-    TwilioPlugin.TwilioVoiceClient.prototype.calldiddisconnect = function(fn) {
+    TwilioVoiceClient.prototype.calldiddisconnect = function(fn) {
         delegate['oncalldiddisconnect'] = fn;
     }
 
-    TwilioPlugin.install = function() {
-        if (!window.Twilio) window.Twilio = {};
-        if (!window.Twilio.TwilioVoiceClient) window.Twilio.TwilioVoiceClient = new TwilioPlugin.TwilioVoiceClient();
-    }
- TwilioPlugin.install();
+    module.exports = new TwilioVoiceClient()
 
-})()
+})(module, require)


### PR DESCRIPTION
First and foremost, Thanks for all the great work!

PR refactors `www/TwilioVoicePlugin.js` to export a new instance of `TwilioVoiceClient` as an AMD module.

Also updates `plugin.xml` to use the refactored js-module in order to autoload the client under the global (window) object as `Twilio.TwilioVoiceClient`.