### PR TITLE
Create unique class name for GCM Receiver

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,7 +39,7 @@
         </receiver>     
 
         <receiver
-            android:name="com.google.android.gms.gcm.GcmReceiver"
+            android:name="com.phonegap.plugins.twiliovoice.gcm.GcmReceiver"
             android:exported="true"
             android:permission="com.google.android.c2dm.permission.SEND">
             <intent-filter>
@@ -94,6 +94,8 @@
                 target-dir="src/com/phonegap/plugins/twiliovoice" />
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/BootCompletedReceiver.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice" />
+        <source-file src="src/android/com/phonegap/plugins/twiliovoice/gcm/GcmReceiver.java"
+                target-dir="src/com/phonegap/plugins/twiliovoice/gcm" />
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/gcm/GCMRegistrationService.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice/gcm" />
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/gcm/VoiceGCMListenerService.java"

--- a/src/android/com/phonegap/plugins/twiliovoice/gcm/GcmReceiver.java
+++ b/src/android/com/phonegap/plugins/twiliovoice/gcm/GcmReceiver.java
@@ -1,0 +1,7 @@
+package com.phonegap.plugins.twiliovoice.gcm;
+
+import com.google.android.gms.gcm.GcmReceiver
+
+public class GcmReceiver extends GcmReceiver {
+
+}


### PR DESCRIPTION
This is a follow up pull request on #23 and #21 to resolve the Android build issue.