### PR TITLE
Updated callInviteReceived Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Preference | Example | Description
 INCOMING_CALL_APP_NAME | PhoneApp | Users will get a notification that they have an inbound call (either a standard Push notification, or a CallKit screen) - this name is shown to the users.
 GCM_SENDER_ID | 12345 | This is the Google Cloud Messaging Sender ID used for sending push notifications. If you aren't using Android, you can set GCM_SENDER_ID to a dummy value, like 123. The GCM Sender ID has to match the one you already use inside your application - you can only register with one at a time. 
 ENABLE_CALL_KIT | true | This plugin has optional CallKit support for iOS 10 and above. ENABLE_CALL_KIT should be "true" or "false"
+MASK_INCOMING_PHONE_NUMBER | false | This plugin has optional ability to mask the incoming phone number. MASK_INCOMING_PHONE_NUMBER should be "true" or "false"

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,6 +26,9 @@
     <!-- Necessary to enable CallKit on iOS -->
     <preference name="ENABLE_CALL_KIT" default="false"/>
 
+    <!-- Option to mask the incoming phone number for privacy -->
+    <preference name="MASK_INCOMING_PHONE_NUMBER" default="false"/>
+
      <!-- android -->
     <platform name="android">
         <config-file target="AndroidManifest.xml" parent="/manifest">
@@ -140,6 +143,11 @@
         <!-- Add Enable CallKit Preference to plist -->
         <config-file target="*-Info.plist" parent="TVPEnableCallKit">
           <string>$ENABLE_CALL_KIT</string>
+        </config-file>
+        
+        <!-- Add Enable CallKit Preference to plist -->
+        <config-file target="*-Info.plist" parent="TVPMaskIncomingPhoneNumber">
+          <string>$MASK_INCOMING_PHONE_NUMBER</string>
         </config-file>
 
         <!-- Add push entitlements -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -157,7 +157,7 @@
         <resource-file src="sounds/ringing.wav" />
         <resource-file src="sounds/traditionalring.mp3" />
         <info>
-You need to download __Twilio Voice SDK for iOS__ from https://media.twiliocdn.com/sdk/ios/voice/latest/twilio-voice-ios.tar.bz2. Uncompress the download - you will need to follow two steps that plugman can not do yet:
+You need to download __Twilio Voice SDK for iOS__ from https://media.twiliocdn.com/sdk/ios/voice/releases/2.0.1/twilio-voice-ios-2.0.1.tar.bz2. Uncompress the download - you will need to follow two steps that plugman can not do yet:
 
 * Add the Twilio Voice framework (TwilioVoice.framework) to your Xcode project
 * Add the Twilio Voice framework (TwilioVoice.framework) as an embedded binary to your Xcode project

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -264,6 +264,14 @@
 
 #pragma mark TVONotificationDelegate
 - (void)callInviteReceived:(TVOCallInvite *)callInvite {
+    if (callInvite.state == TVOCallInviteStatePending) {
+        [self handleCallInviteReceived:callInvite];
+    } else if (callInvite.state == TVOCallInviteStateCanceled) {
+        [self handleCallInviteCanceled:callInvite];
+    }
+}
+
+- (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"Call Invite Received: %@", callInvite.uuid);
     self.callInvite = callInvite;
     NSDictionary *callInviteProperties = @{
@@ -283,7 +291,7 @@
     [self javascriptCallback:@"oncallinvitereceived" withArguments:callInviteProperties];
 }
 
-- (void)callInviteCancelled:(TVOCallInvite *)callInvite {
+- (void)handleCallInviteCanceled:(TVOCallInvite *)callInvite {
     NSLog(@"Call Invite Cancelled: %@", callInvite.uuid);
     if (self.enableCallKit) {
         [self performEndCallActionWithUUID:callInvite.uuid];

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -285,11 +285,11 @@
 
 - (void)handleCallInviteReceived:(TVOCallInvite *)callInvite {
     NSLog(@"Call Invite Received: %@", callInvite.uuid);
-    // Two simlutaneous callInvites are not supported by Twilio and cause an error
+    // Two simlutaneous callInvites or calls are not supported by Twilio and cause an error
     // if the user attempts to answer the second call invite through CallKit.
     // Rather than surface the second invite, just reject it which will most likely
     // result in the second invite going to voicemail
-    if (self.callInvite == nil) {
+    if (self.callInvite == nil && self.call == nil) {
         self.callInvite = callInvite;
         NSDictionary *callInviteProperties = @{
                                                @"from":callInvite.from,

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -557,6 +557,7 @@
     if (self.callInvite && self.callInvite.state == TVOCallInviteStatePending) {
         [self.callInvite reject];
         self.callInvite = nil;
+        [self javascriptCallback:@"oncallinvitecanceled"];
     } else if (self.call) {
         [self.call disconnect];
     }

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -377,7 +377,6 @@
         NSLog(@"Call disconnected");
     }
     
-    [self performEndCallActionWithUUID:call.uuid];
     [self callDisconnected:call];
 }
 

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -146,6 +146,9 @@
 
 - (void) call:(CDVInvokedUrlCommand*)command {
     if ([command.arguments count] > 0) {
+        [TwilioVoice configureAudioSession];
+        TwilioVoice.audioEnabled = YES;
+
         self.accessToken = command.arguments[0];
         if ([command.arguments count] > 1) {
             NSDictionary *params = command.arguments[1];
@@ -158,7 +161,6 @@
             self.call = [TwilioVoice call:self.accessToken
                                                     params:@{}
                                                   delegate:self];
-
         }
     }
 }
@@ -376,7 +378,7 @@
     } else {
         NSLog(@"Call disconnected");
     }
-    
+
     [self callDisconnected:call];
 }
 

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -366,7 +366,9 @@
 
 - (void)call:(TVOCall *)call didFailToConnectWithError:(NSError *)error {
     NSLog(@"Call Did Fail with Error: %@, %@", [call description], [error localizedDescription]);
-    self.call = nil;
+    if (self.enableCallKit) {
+        self.callKitCompletionCallback(NO);
+    }
     [self callDisconnected:call];
     [self javascriptErrorback:error];
 }
@@ -391,6 +393,7 @@
     }
     
     self.call = nil;
+    self.callKitCompletionCallback = nil;
     [self javascriptCallback:@"oncalldiddisconnect"];
 }
 


### PR DESCRIPTION
The new library does not have an explicit `callInviteCanceled` event anymore. After a solid couple rounds with QA, I believe this is the only update to the interface that I missed.