### PR TITLE
Bug Fix - Fixed CallKit Outgoing Calls

### DIFF
--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -159,7 +159,7 @@
             NSString *incomingCallAppName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"TVPIncomingCallAppName"];
             [self performStartCallActionWithUUID:uuid handle:incomingCallAppName];
         } else {
-            NSLog(@"Making call to with params %@", params);
+            NSLog(@"Making call to with params %@", self.outgoingCallParams);
             self.call = [TwilioVoice call:self.accessToken
                                      params:(self.outgoingCallParams != nil ? self.outgoingCallParams : @{})
                                      delegate:self];

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -532,7 +532,6 @@
     NSLog(@"provider:performStartCallAction:");
 
     [TwilioVoice configureAudioSession];
-    [self toggleAudioRoute:YES];
     TwilioVoice.audioEnabled = NO;
     
     [self.callKitProvider reportOutgoingCallWithUUID:action.callUUID startedConnectingAtDate:[NSDate date]];
@@ -640,7 +639,6 @@
             
             // RCP: Workaround per https://forums.developer.apple.com/message/169511
             [TwilioVoice configureAudioSession];
-            [self toggleAudioRoute:YES];
         }
         else {
             NSLog(@"Failed to report incoming call successfully: %@.", [error localizedDescription]);

--- a/src/ios/TwilioVoicePlugin.m
+++ b/src/ios/TwilioVoicePlugin.m
@@ -153,9 +153,18 @@
         if ([command.arguments count] > 1) {
             self.outgoingCallParams = command.arguments[1];
         }
-        NSUUID *uuid = [NSUUID UUID];
-        NSString *incomingCallAppName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"TVPIncomingCallAppName"];
-        [self performStartCallActionWithUUID:uuid handle:incomingCallAppName];
+
+        if (self.enableCallKit) {
+            NSUUID *uuid = [NSUUID UUID];
+            NSString *incomingCallAppName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"TVPIncomingCallAppName"];
+            [self performStartCallActionWithUUID:uuid handle:incomingCallAppName];
+        } else {
+            NSLog(@"Making call to with params %@", params);
+            self.call = [TwilioVoice call:self.accessToken
+                                     params:(self.outgoingCallParams != nil ? self.outgoingCallParams : @{})
+                                     delegate:self];
+            self.outgoingCallParams = nil;
+        }
     }
 }
 


### PR DESCRIPTION
The original way that outgoing calls were placed was causing issues with CallKit and creating unstable states. This lead to calls not terminating properly and hanging in the background with CallKit.